### PR TITLE
Migrate to zokrates v0.6

### DIFF
--- a/generate_zokrates_files/generate_merkle_proof_validation.py
+++ b/generate_zokrates_files/generate_merkle_proof_validation.py
@@ -3,8 +3,8 @@ import math
 
 def generate_create_hash():
     return '''
-def create_hash(u32[20] preimage) -> (u32[8]):
-	u32[8] intermediary = sha256for1024(preimage[0..8], preimage[8..16], [...preimage[16..20], 0x80000000, ...[0x00000000; 3]], [...[0x00000000; 7], 0x00000280])
+def create_hash(bool[640] preimage) -> (bool[256]):
+	bool[256] intermediary = sha256for1024(preimage[0..256], preimage[256..512], [...preimage[512..640], true, ...[false; 127]], [...[false; 246], true, false, true, ...[false; 7]])
     return sha256only(intermediary)
 
     '''
@@ -13,23 +13,24 @@ def create_hash(u32[20] preimage) -> (u32[8]):
 def generate_merkle_proof_validation_code(number_leafs):
     layers = math.ceil(math.log(number_leafs, 2))
     code = []
-
     code.append('import "hashes/pedersen/512bit.zok" as pedersenhash')
-    code.append('import "hashes/sha256/1024bit.zok" as sha256for1024\n')
-    code.append('import "hashes/sha256/256bitPadded.zok" as sha256only\n')
-    code.append('import "utils/pack/u32/pack128.zok" as pack_4_u32_to_field\n')
-    code.append('import "utils/pack/u32/unpack128.zok" as unpack_field_to_4_u32\n')
+    code.append('import "hashes/sha256/embed/1024bit.zok" as sha256for1024\n')
+    code.append('import "hashes/sha256/embed/256bitPadded.zok" as sha256only\n')
+    code.append('import "utils/pack/bool/pack128.zok" as pack_128_bool_to_field\n')
+    code.append('import "utils/pack/u32/pack128.zok" as pack_u32_4_to_field\n')
+    code.append('import "utils/pack/bool/unpack128.zok" as unpack_field_to_128_bool\n')
+    code.append('import "utils/casts/bool_128_to_u32_4.zok" as bool_128_to_u32_4\n')
 
 
     code.append(generate_create_hash())
     code.append('def main(field[5] preimage_field, private u32[{layers}][8] path, private field[{layers}] lr) -> (field[2][2]):'.format(layers=layers))
-    code.append('\tu32[20] preimage = [...unpack_field_to_4_u32(preimage_field[0]), ...unpack_field_to_4_u32(preimage_field[1]), ...unpack_field_to_4_u32(preimage_field[2]), ...unpack_field_to_4_u32(preimage_field[3]), ...unpack_field_to_4_u32(preimage_field[4])]')
-    code.append('\tu32[8] proof_header = create_hash(preimage)')
-    code.append('\tu32[8] layer0 = if lr[0] == 0 then pedersenhash([...path[0], ...proof_header]) else pedersenhash([...proof_header, ...path[0]]) fi')
+    code.append('\tbool[640] preimage = [...unpack_field_to_128_bool(preimage_field[0]), ...unpack_field_to_128_bool(preimage_field[1]), ...unpack_field_to_128_bool(preimage_field[2]), ...unpack_field_to_128_bool(preimage_field[3]), ...unpack_field_to_128_bool(preimage_field[4])]')
+    code.append('\tbool[256] proof_header = create_hash(preimage)')
+    code.append('\tu32[8] layer0 = if lr[0] == 0 then pedersenhash([...path[0], ...bool_128_to_u32_4(proof_header[0..128]), ...bool_128_to_u32_4(proof_header[128..256])]) else pedersenhash([...bool_128_to_u32_4(proof_header[0..128]), ...bool_128_to_u32_4(proof_header[128..256]), ...path[0]]) fi')
 
     for i in range(1, layers):
         code.append('\tu32[8] layer{i} = if lr[{i}] == 0 then pedersenhash([...path[{i}], ...layer{preceeding}]) else pedersenhash([...layer{preceeding}, ...path[{i}]]) fi'.format(i=i, preceeding= i-1))
 
-    code.append('\treturn [[pack_4_u32_to_field(proof_header[0..4]), pack_4_u32_to_field(proof_header[4..8])], [pack_4_u32_to_field(layer{layers}[0..4]), pack_4_u32_to_field(layer{layers}[4..8])]]'.format(layers=layers-1))
+    code.append('\treturn [[pack_128_bool_to_field(proof_header[0..128]), pack_128_bool_to_field(proof_header[128..256])], [pack_u32_4_to_field(layer{layers}[0..4]), pack_u32_4_to_field(layer{layers}[4..8])]]'.format(layers=layers-1))
 
     return '\n'.join(code)

--- a/generate_zokrates_files/generate_merkle_proof_validation.py
+++ b/generate_zokrates_files/generate_merkle_proof_validation.py
@@ -3,21 +3,9 @@ import math
 
 def generate_create_hash():
     return '''
-def create_hash(field[5] preimage) -> (field[256]):
-	a = unpack128(preimage[0])
-	b = unpack128(preimage[1])
-	c = unpack128(preimage[2])
-	d = unpack128(preimage[3])
-	e = unpack128(preimage[4])
-
-	field[256] preimage1 = [...a, ...b]
-    field[256] preimage2 = [...c, ...d]
-    field[256] preimage3 = [...[...e, 1], ...[0; 127]]
-    field[256] dummy = [...[0; 246], ...[1, 0, 1, 0, 0, 0, 0, 0, 0, 0]] //second array indicates length of preimage = 640bit
-
-    intermediary = sha256for1024(preimage1, preimage2, preimage3, dummy)
-    
-	return sha256only(intermediary)
+def create_hash(u32[20] preimage) -> (u32[8]):
+	u32[8] intermediary = sha256for1024(preimage[0..8], preimage[8..16], [...preimage[16..20], 0x80000000, ...[0x00000000; 3]], [...[0x00000000; 7], 0x00000280])
+    return sha256only(intermediary)
 
     '''
 
@@ -27,24 +15,18 @@ def generate_merkle_proof_validation_code(number_leafs):
     code = []
 
     code.append('import "hashes/pedersen/512bit.zok" as pedersenhash')
-    code.append('import "utils/pack/pack128.zok" as pack128\n')
-    code.append('import "utils/pack/unpack128.zok" as unpack128\n')
     code.append('import "hashes/sha256/1024bit.zok" as sha256for1024\n')
-    code.append('import "../sha256only.zok" as sha256only')
+    code.append('import "hashes/sha256/256bitPadded.zok" as sha256only\n')
+
 
     code.append(generate_create_hash())
-
-    code.append('def main(field[5] preimage, private field[{layers}][256] path, private field[{layers}] lr) -> (field[4]):'.format(layers=layers))
-    code.append('\tunpacked_proof_header = create_hash(preimage)')
-    code.append('\tfield[256] layer0 = if lr[0] == 0 then pedersenhash([...path[0], ...unpacked_proof_header]) else pedersenhash([...unpacked_proof_header, ...path[0]]) fi')
+    code.append('def main(u32[20] preimage, private u32[{layers}][8] path, private field[{layers}] lr) -> (u32[2][8]):'.format(layers=layers))
+    code.append('\tu32[8] proof_header = create_hash(preimage)')
+    code.append('\tu32[8] layer0 = if lr[0] == 0 then pedersenhash([...path[0], ...proof_header]) else pedersenhash([...proof_header, ...path[0]]) fi')
 
     for i in range(1, layers):
-        code.append('\tfield[256] layer{i} = if lr[{i}] == 0 then pedersenhash([...path[{i}], ...layer{preceeding}]) else pedersenhash([...layer{preceeding}, ...path[{i}]]) fi'.format(i=i, preceeding= i-1))
+        code.append('\tu32[8] layer{i} = if lr[{i}] == 0 then pedersenhash([...path[{i}], ...layer{preceeding}]) else pedersenhash([...layer{preceeding}, ...path[{i}]]) fi'.format(i=i, preceeding= i-1))
 
-    code.append('\tres0 = pack128(layer{layers}[0..128])'.format(layers=layers-1))
-    code.append('\tres1 = pack128(layer{layers}[128..256])'.format(layers=layers-1))
-
-    code.append('\tfield[2] proof_header = [pack128(unpacked_proof_header[0..128]), pack128(unpacked_proof_header[128..256])]')
-    code.append('\treturn [...proof_header, res0, res1]')
+    code.append('\treturn [proof_header, layer{layers}]'.format(layers=layers-1))
 
     return '\n'.join(code)

--- a/generate_zokrates_files/generate_root_computation.py
+++ b/generate_zokrates_files/generate_root_computation.py
@@ -4,9 +4,9 @@ import math
 
 def generate_compute_root(number_leafs):
     if number_leafs > 2:
-        output = '\tu32[{len}][8] layer{layer} = [\n'.format(len=math.ceil(number_leafs/2), layer=(math.ceil(math.log(number_leafs,2))-1))
+        output = '\tbool[{len}][256] layer{layer} = [\n'.format(len=math.ceil(number_leafs/2), layer=(math.ceil(math.log(number_leafs,2))-1))
     else:
-        output = '\tu32[8] layer{layer} = '.format(layer=(math.ceil(math.log(number_leafs,2))-1))
+        output = '\tbool[256] layer{layer} = '.format(layer=(math.ceil(math.log(number_leafs,2))-1))
     for i in range(0, number_leafs-2, 2):
         output = output + '\t\tpedersenhash([...layer{layer}[{a}], ...layer{layer}[{b}]]),\n'.format(a=i, b=i+1, layer=math.ceil(math.log(number_leafs,2)))
     output = output + '\t\tpedersenhash([...layer{layer}[{a}], ...layer{layer}[{b}]])\n'.format(a=number_leafs-2 if number_leafs % 2 == 0 else number_leafs-1, b=number_leafs-1, layer=math.ceil(math.log(number_leafs,2)))
@@ -21,8 +21,8 @@ def generate_compute_root(number_leafs):
 
 def generate_root_code(number_leafs):
     output = ('import "hashes/pedersen/512bit.zok" as pedersenhash\n' +
-            'import "utils/pack/u32/pack128.zok" as u32_4_to_field\n' +
-        'def main(u32[{number_leafs}][8] layer{layer}) -> (field[2]):\n'.format(number_leafs=number_leafs,layer=math.ceil(math.log(number_leafs,2))) +
+            'import "utils/pack/bool/pack128.zok" as bool_128_to_field\n' +
+        'def main(bool[{number_leafs}][256] layer{layer}) -> (field[2]):\n'.format(number_leafs=number_leafs,layer=math.ceil(math.log(number_leafs,2))) +
         generate_compute_root(number_leafs) +
-        '\treturn [u32_4_to_field(layer0[0..4]), u32_4_to_field(layer0[4..8])]')
+        '\treturn [bool_128_to_field(layer0[0..128]), bool_128_to_field(layer0[128..256])]')
     return output

--- a/generate_zokrates_files/generate_root_computation.py
+++ b/generate_zokrates_files/generate_root_computation.py
@@ -20,7 +20,7 @@ def generate_compute_root(number_leafs):
 
 
 def generate_root_code(number_leafs):
-    output = ('import "hashes/pedersen/512bit.zok" as pedersenhash\n' +
+    output = ('import "hashes/pedersen/512bitBool.zok" as pedersenhash\n' +
             'import "utils/pack/bool/pack128.zok" as bool_128_to_field\n' +
         'def main(bool[{number_leafs}][256] layer{layer}) -> (field[2]):\n'.format(number_leafs=number_leafs,layer=math.ceil(math.log(number_leafs,2))) +
         generate_compute_root(number_leafs) +

--- a/generate_zokrates_files/generate_root_computation.py
+++ b/generate_zokrates_files/generate_root_computation.py
@@ -21,7 +21,8 @@ def generate_compute_root(number_leafs):
 
 def generate_root_code(number_leafs):
     output = ('import "hashes/pedersen/512bit.zok" as pedersenhash\n' +
-        'def main(u32[{number_leafs}][8] layer{layer}) -> (u32[8]):\n'.format(number_leafs=number_leafs,layer=math.ceil(math.log(number_leafs,2))) +
+            'import "utils/pack/u32/pack128.zok" as u32_4_to_field\n' +
+        'def main(u32[{number_leafs}][8] layer{layer}) -> (field[2]):\n'.format(number_leafs=number_leafs,layer=math.ceil(math.log(number_leafs,2))) +
         generate_compute_root(number_leafs) +
-        '\treturn layer0')
+        '\treturn [u32_4_to_field(layer0[0..4]), u32_4_to_field(layer0[4..8])]')
     return output

--- a/generate_zokrates_files/generate_root_computation.py
+++ b/generate_zokrates_files/generate_root_computation.py
@@ -1,11 +1,12 @@
+
 import math
 
 
 def generate_compute_root(number_leafs):
     if number_leafs > 2:
-        output = '\tfield[{len}][256] layer{layer} = [\n'.format(len=math.ceil(number_leafs/2), layer=(math.ceil(math.log(number_leafs,2))-1))
+        output = '\tu32[{len}][8] layer{layer} = [\n'.format(len=math.ceil(number_leafs/2), layer=(math.ceil(math.log(number_leafs,2))-1))
     else:
-        output = '\tfield[256] layer{layer} = '.format(layer=(math.ceil(math.log(number_leafs,2))-1))
+        output = '\tu32[8] layer{layer} = '.format(layer=(math.ceil(math.log(number_leafs,2))-1))
     for i in range(0, number_leafs-2, 2):
         output = output + '\t\tpedersenhash([...layer{layer}[{a}], ...layer{layer}[{b}]]),\n'.format(a=i, b=i+1, layer=math.ceil(math.log(number_leafs,2)))
     output = output + '\t\tpedersenhash([...layer{layer}[{a}], ...layer{layer}[{b}]])\n'.format(a=number_leafs-2 if number_leafs % 2 == 0 else number_leafs-1, b=number_leafs-1, layer=math.ceil(math.log(number_leafs,2)))
@@ -19,10 +20,8 @@ def generate_compute_root(number_leafs):
 
 
 def generate_root_code(number_leafs):
-    output = ('import "hashes/pedersen/512bit.zok" as pedersenhash\nimport "utils/pack/unpack128.zok" as unpack128\nimport "utils/pack/pack128.zok" as pack128\n' +
-        'def main(field[{number_leafs}][256] layer{layer}) -> (field[2]):\n'.format(number_leafs=number_leafs,layer=math.ceil(math.log(number_leafs,2))) +
+    output = ('import "hashes/pedersen/512bit.zok" as pedersenhash\n' +
+        'def main(u32[{number_leafs}][8] layer{layer}) -> (u32[8]):\n'.format(number_leafs=number_leafs,layer=math.ceil(math.log(number_leafs,2))) +
         generate_compute_root(number_leafs) +
-        '\tfield res0 = pack128(layer0[0..128])\n' +
-        '\tfield res1 = pack128(layer0[128..256])\n' +
-        '\treturn [res0, res1]')
+        '\treturn layer0')
     return output

--- a/generate_zokrates_files/generate_validation.py
+++ b/generate_zokrates_files/generate_validation.py
@@ -1,13 +1,12 @@
 def generate_validation_code(n_blocks):
-    static_code = """import "EMBED/u32_to_bits" as u32_to_bits
+    static_code = """
+import "EMBED/u32_to_bits" as u32_to_bits
 import "EMBED/u32_from_bits" as u32_from_bits
-import "utils/casts/u32_4_to_bool_128.zok" as u32_4_to_bool_128
-import "utils/pack/u32/pack128.zok" as u32_4_to_field
 import "utils/pack/bool/pack128.zok" as pack_128_bool_to_field
 import "utils/pack/bool/unpack128.zok" as unpack_field_to_128_bool
 import "utils/pack/u32/unpack128.zok" as unpack_field_to_4_u32
-import "hashes/sha256/1024bit.zok" as sha256for1024
-import "hashes/sha256/256bitPadded.zok" as sha256only
+import "hashes/sha256/embed/1024bit.zok" as sha256for1024
+import "hashes/sha256/embed/256bitPadded.zok" as sha256only
 import "./getHexLength.zok" as getHexLength
 import "./compute_merkle_root.zok" as compute_merkle_root
 def toBigEndian(bool[32] value) -> (bool[32]):
@@ -134,23 +133,17 @@ def validate_target(field epoch_head, u32 epoch_tail, u32 next_epoch_head) -> (b
     delta = if target >= encoded_target_extended then delta else maxVariance + 1 fi
     bool valid = if delta <= maxVariance then true else false fi
 return valid, current_target
-def validate_block_header(u32 reference_target, u32[8] prev_block_hash, field[5] preimage_field) -> (u32[8]):
-   u32[20] preimage = [...unpack_field_to_4_u32(preimage_field[0]), ...unpack_field_to_4_u32(preimage_field[1]), ...unpack_field_to_4_u32(preimage_field[2]), ...unpack_field_to_4_u32(preimage_field[3]), ...unpack_field_to_4_u32(preimage_field[4])]
-	// preImage: [0] -> Block version, [1:8] -> prev_block_hash, [9:16] -> merkle root, [17:19] => time, target, nonce 
-    assert(preimage[1] == prev_block_hash[0] && \\
-            preimage[2] == prev_block_hash[1] && \\
-            preimage[3] == prev_block_hash[2] && \\
-            preimage[4] == prev_block_hash[3] && \\
-            preimage[5] == prev_block_hash[4] && \\
-            preimage[6] == prev_block_hash[5] && \\
-            preimage[7] == prev_block_hash[6] && \\
-            preimage[8] == prev_block_hash[7])
+def validate_block_header(u32 reference_target, bool[256] prev_block_hash, field[5] preimage_field) -> (bool[256]):
+    // preImage: [0-32] -> Block version, [32-288] -> prev_block_hash, [288:544] -> merkle root, [544:640] => time, target, nonce 
+    bool[640] preimage = [...unpack_field_to_128_bool(preimage_field[0]), ...unpack_field_to_128_bool(preimage_field[1]), ...unpack_field_to_128_bool(preimage_field[2]), ...unpack_field_to_128_bool(preimage_field[3]), ...unpack_field_to_128_bool(preimage_field[4])]
+    assert(pack_128_bool_to_field(preimage[32..160]) == pack_128_bool_to_field(prev_block_hash[0..128]) && \
+           pack_128_bool_to_field(preimage[160..288]) == pack_128_bool_to_field(prev_block_hash[128..256]))
     // converting to big endian is not necessary here, as reference target is encoded little endian
-    assert(preimage[18] == reference_target)
-    u32[8] intermediary = sha256for1024(preimage[0..8], preimage[8..16], [...preimage[16..20], 0x80000000, ...[0x00000000; 3]], [...[0x00000000; 7], 0x00000280])
-    u32[8] r = sha256only(intermediary)
-    field target = packTarget(toBigEndian(u32_to_bits(preimage[18])))
-    assert(target > pack_128_bool_to_field(toBigEndian(u32_4_to_bool_128(r[4..8]))))
+    assert(u32_from_bits(preimage[576..608]) == reference_target)
+    bool[256] intermediary = sha256for1024(preimage[0..256], preimage[256..512], [...preimage[512..640], true, ...[false; 127]], [...[false; 246], true, false, true, ...[false; 7]])
+    bool[256] r = sha256only(intermediary)
+    field target = packTarget(toBigEndian(preimage[576..608]))
+    assert(target > pack_128_bool_to_field(toBigEndian(r[128..256])))
 return r
 """
     main_block = []
@@ -158,9 +151,9 @@ return r
     main_block.append("def main(field epoch_head, field[2] prev_block_hash, private field[{n_intermediate}][5] intermediate_blocks, field[5] final_block_field) -> (bool, field[5]):".format(n_intermediate=(n_blocks-1)))
     main_block.append("""
     u32 reference_target = unpack_field_to_4_u32(epoch_head)[2]
-    u32[8] block_hash = [...unpack_field_to_4_u32(prev_block_hash[0]), ...unpack_field_to_4_u32(prev_block_hash[1])]
+    bool[256] block_hash = [...unpack_field_to_128_bool(prev_block_hash[0]), ...unpack_field_to_128_bool(prev_block_hash[1])]
     u32 final_block_target = unpack_field_to_4_u32(final_block_field[4])[2]
-    u32[{n_hashes}][8] blocks = [[0x00000000;8];{n_hashes}]
+    bool[{n_hashes}][256] blocks = [[false;256];{n_hashes}]
     for field i in 0..{n_intermediate} do
       block_hash = validate_block_header(reference_target, block_hash, intermediate_blocks[i])
       blocks[i] = block_hash
@@ -171,7 +164,7 @@ return r
     blocks[{n_intermediate}] = block_hash
     bool targetValid, field target = validate_target(epoch_head, unpack_field_to_4_u32(intermediate_blocks[0][4])[1], final_block_target)
     field[2] merkle_root = compute_merkle_root(blocks)
-    field[2] block = [u32_4_to_field(blocks[{n_intermediate}][0..4]), u32_4_to_field(blocks[{n_intermediate}][4..8])]
+    field[2] block = [pack_128_bool_to_field(blocks[{n_intermediate}][0..128]), pack_128_bool_to_field(blocks[{n_intermediate}][128..256])]
 return targetValid, [target, ...block, ...merkle_root]
     """.format(n_intermediate=(n_blocks - 1)))
     return static_code + "\n".join(main_block)

--- a/generate_zokrates_files/generate_validation.py
+++ b/generate_zokrates_files/generate_validation.py
@@ -1,25 +1,26 @@
 def generate_validation_code(n_blocks):
-    static_code = """import "utils/pack/pack128.zok" as pack128
-import "utils/pack/unpack128.zok" as unpack128
+    static_code = """import "EMBED/u32_to_bits" as u32_to_bits
+import "EMBED/u32_from_bits" as u32_from_bits
+import "utils/casts/u32_4_to_bool_128.zok" as u32_4_to_bool_128
+import "utils/pack/bool/pack128.zok" as pack_128_bool_to_field
+import "utils/pack/bool/unpack128.zok" as unpack_field_to_128_bool
+import "utils/pack/u32/unpack128.zok" as unpack_field_to_4_u32
 import "hashes/sha256/1024bit.zok" as sha256for1024
-import "./sha256only.zok" as sha256only
+import "hashes/sha256/256bitPadded.zok" as sha256only
 import "./getHexLength.zok" as getHexLength
 import "./compute_merkle_root.zok" as compute_merkle_root
-
-def toBigEndian(field[32] value) -> (field[32]):
+def toBigEndian(bool[32] value) -> (bool[32]):
     return [
             ...value[24..32],
             ...value[16..24],
             ...value[8..16],
             ...value[0..8]]
-
-def toBigEndian(field[24] value) -> (field[24]):
+def toBigEndian(bool[24] value) -> (bool[24]):
     return [
             ...value[16..24],
             ...value[8..16],
             ...value[0..8]]
-
-def toBigEndian(field[128] value) -> (field[128]):
+def toBigEndian(bool[128] value) -> (bool[128]):
     return [
             ...value[120..128],
             ...value[112..120],
@@ -37,73 +38,69 @@ def toBigEndian(field[128] value) -> (field[128]):
             ...value[16..24],
             ...value[8..16],
             ...value[0..8]]
-
 def packMaxVariance(field length) -> (field):
     field result = 0
-    result = if length == 1 then pack128([...[0; 124], ...[1; 4]]) else result fi
-    result = if length == 2 then pack128([...[0; 120], ...[1; 8]]) else result fi
-    result = if length == 3 then pack128([...[0; 116], ...[1; 12]]) else result fi
-    result = if length == 4 then pack128([...[0; 112], ...[1; 16]]) else result fi
-    result = if length == 5 then pack128([...[0; 108], ...[1; 20]]) else result fi
-    result = if length == 6 then pack128([...[0; 104], ...[1; 24]]) else result fi
-    result = if length == 7 then pack128([...[0; 100], ...[1; 28]]) else result fi
-    result = if length == 8 then pack128([...[0; 96], ...[1; 32]]) else result fi
-    result = if length == 9 then pack128([...[0; 92], ...[1; 36]]) else result fi
-    result = if length == 10 then pack128([...[0; 88], ...[1; 40]]) else result fi
-    result = if length == 11 then pack128([...[0; 84], ...[1; 44]]) else result fi
-    result = if length == 12 then pack128([...[0; 80], ...[1; 48]]) else result fi
-    result = if length == 13 then pack128([...[0; 76], ...[1; 52]]) else result fi
-    result = if length == 14 then pack128([...[0; 72], ...[1; 56]]) else result fi
-    result = if length == 15 then pack128([...[0; 68], ...[1; 60]]) else result fi
-    result = if length == 16 then pack128([...[0; 64], ...[1; 64]]) else result fi
-    result = if length == 17 then pack128([...[0; 60], ...[1; 68]]) else result fi
-    result = if length == 18 then pack128([...[0; 56], ...[1; 72]]) else result fi
-    result = if length == 19 then pack128([...[0; 52], ...[1; 76]]) else result fi
-    result = if length == 20 then pack128([...[0; 48], ...[1; 80]]) else result fi
-    result = if length == 21 then pack128([...[0; 44], ...[1; 84]]) else result fi
-    result = if length == 22 then pack128([...[0; 40], ...[1; 88]]) else result fi
-    result = if length == 23 then pack128([...[0; 36], ...[1; 92]]) else result fi
-    result = if length == 24 then pack128([...[0; 32], ...[1; 96]]) else result fi
-    result = if length == 25 then pack128([...[0; 28], ...[1; 100]]) else result fi
-    result = if length == 26 then pack128([...[0; 24], ...[1; 104]]) else result fi
-    result = if length == 27 then pack128([...[0; 20], ...[1; 108]]) else result fi
-    result = if length == 28 then pack128([...[0; 16], ...[1; 112]]) else result fi
-    result = if length == 29 then pack128([...[0; 12], ...[1; 116]]) else result fi
-    result = if length == 30 then pack128([...[0; 8], ...[1; 120]]) else result fi
-    result = if length == 31 then pack128([...[0; 4], ...[1; 124]]) else result fi
-    result = if length == 32 then pack128([1; 128]) else result fi
+    result = if length == 1 then pack_128_bool_to_field([...[false; 124], ...[true; 4]]) else result fi
+    result = if length == 2 then pack_128_bool_to_field([...[false; 120], ...[true; 8]]) else result fi
+    result = if length == 3 then pack_128_bool_to_field([...[false; 116], ...[true; 12]]) else result fi
+    result = if length == 4 then pack_128_bool_to_field([...[false; 112], ...[true; 16]]) else result fi
+    result = if length == 5 then pack_128_bool_to_field([...[false; 108], ...[true; 20]]) else result fi
+    result = if length == 6 then pack_128_bool_to_field([...[false; 104], ...[true; 24]]) else result fi
+    result = if length == 7 then pack_128_bool_to_field([...[false; 100], ...[true; 28]]) else result fi
+    result = if length == 8 then pack_128_bool_to_field([...[false; 96], ...[true; 32]]) else result fi
+    result = if length == 9 then pack_128_bool_to_field([...[false; 92], ...[true; 36]]) else result fi
+    result = if length == 10 then pack_128_bool_to_field([...[false; 88], ...[true; 40]]) else result fi
+    result = if length == 11 then pack_128_bool_to_field([...[false; 84], ...[true; 44]]) else result fi
+    result = if length == 12 then pack_128_bool_to_field([...[false; 80], ...[true; 48]]) else result fi
+    result = if length == 13 then pack_128_bool_to_field([...[false; 76], ...[true; 52]]) else result fi
+    result = if length == 14 then pack_128_bool_to_field([...[false; 72], ...[true; 56]]) else result fi
+    result = if length == 15 then pack_128_bool_to_field([...[false; 68], ...[true; 60]]) else result fi
+    result = if length == 16 then pack_128_bool_to_field([...[false; 64], ...[true; 64]]) else result fi
+    result = if length == 17 then pack_128_bool_to_field([...[false; 60], ...[true; 68]]) else result fi
+    result = if length == 18 then pack_128_bool_to_field([...[false; 56], ...[true; 72]]) else result fi
+    result = if length == 19 then pack_128_bool_to_field([...[false; 52], ...[true; 76]]) else result fi
+    result = if length == 20 then pack_128_bool_to_field([...[false; 48], ...[true; 80]]) else result fi
+    result = if length == 21 then pack_128_bool_to_field([...[false; 44], ...[true; 84]]) else result fi
+    result = if length == 22 then pack_128_bool_to_field([...[false; 40], ...[true; 88]]) else result fi
+    result = if length == 23 then pack_128_bool_to_field([...[false; 36], ...[true; 92]]) else result fi
+    result = if length == 24 then pack_128_bool_to_field([...[false; 32], ...[true; 96]]) else result fi
+    result = if length == 25 then pack_128_bool_to_field([...[false; 28], ...[true; 100]]) else result fi
+    result = if length == 26 then pack_128_bool_to_field([...[false; 24], ...[true; 104]]) else result fi
+    result = if length == 27 then pack_128_bool_to_field([...[false; 20], ...[true; 108]]) else result fi
+    result = if length == 28 then pack_128_bool_to_field([...[false; 16], ...[true; 112]]) else result fi
+    result = if length == 29 then pack_128_bool_to_field([...[false; 12], ...[true; 116]]) else result fi
+    result = if length == 30 then pack_128_bool_to_field([...[false; 8], ...[true; 120]]) else result fi
+    result = if length == 31 then pack_128_bool_to_field([...[false; 4], ...[true; 124]]) else result fi
+    result = if length == 32 then pack_128_bool_to_field([true; 128]) else result fi
 return result
-
-def packTarget(field[32] bits) -> (field):
-    field result = \\
-    if pack128([...[0; 120], ...bits[0..8]]) == 23 then pack128([...[0; 72], ...bits[8..32], ...[0; 32]]) else \\
-      if pack128([...[0; 120], ...bits[0..8]]) == 24 then pack128([...[0; 64], ...bits[8..32], ...[0; 40]]) else \\
-        if pack128([...[0; 120], ...bits[0..8]]) == 25 then pack128([...[0; 56], ...bits[8..32], ...[0; 48]]) else \\
-          if pack128([...[0; 120], ...bits[0..8]]) == 26 then pack128([...[0; 48], ...bits[8..32], ...[0; 56]]) else \\
-            if pack128([...[0; 120], ...bits[0..8]]) == 27 then pack128([...[0; 40], ...bits[8..32], ...[0; 64]]) else \\
-              if pack128([...[0; 120], ...bits[0..8]]) == 28 then pack128([...[0; 32], ...bits[8..32], ...[0; 72]]) else \\
-                if pack128([...[0; 120], ...bits[0..8]]) == 29 then pack128([...[0; 24], ...bits[8..32], ...[0; 80]]) else \\
-                  if pack128([...[0; 120], ...bits[0..8]]) == 30 then pack128([...[0; 16], ...bits[8..32], ...[0; 88]]) else \\
-                    if pack128([...[0; 120], ...bits[0..8]]) == 31 then pack128([...[0; 8], ...bits[8..32], ...[0; 96]]) else \\
-                    pack128([0; 128]) fi \\
-                  fi \\
-                fi \\
-              fi \\
-            fi \\
-          fi \\
-        fi \\
-      fi \\
+def packTarget(bool[32] bits) -> (field):
+    field result = \
+    if pack_128_bool_to_field([...[false; 120], ...bits[0..8]]) == 23 then pack_128_bool_to_field([...[false; 72], ...bits[8..32], ...[false; 32]]) else \
+      if pack_128_bool_to_field([...[false; 120], ...bits[0..8]]) == 24 then pack_128_bool_to_field([...[false; 64], ...bits[8..32], ...[false; 40]]) else \
+        if pack_128_bool_to_field([...[false; 120], ...bits[0..8]]) == 25 then pack_128_bool_to_field([...[false; 56], ...bits[8..32], ...[false; 48]]) else \
+          if pack_128_bool_to_field([...[false; 120], ...bits[0..8]]) == 26 then pack_128_bool_to_field([...[false; 48], ...bits[8..32], ...[false; 56]]) else \
+            if pack_128_bool_to_field([...[false; 120], ...bits[0..8]]) == 27 then pack_128_bool_to_field([...[false; 40], ...bits[8..32], ...[false; 64]]) else \
+              if pack_128_bool_to_field([...[false; 120], ...bits[0..8]]) == 28 then pack_128_bool_to_field([...[false; 32], ...bits[8..32], ...[false; 72]]) else \
+                if pack_128_bool_to_field([...[false; 120], ...bits[0..8]]) == 29 then pack_128_bool_to_field([...[false; 24], ...bits[8..32], ...[false; 80]]) else \
+                  if pack_128_bool_to_field([...[false; 120], ...bits[0..8]]) == 30 then pack_128_bool_to_field([...[false; 16], ...bits[8..32], ...[false; 88]]) else \
+                    if pack_128_bool_to_field([...[false; 120], ...bits[0..8]]) == 31 then pack_128_bool_to_field([...[false; 8], ...bits[8..32], ...[false; 96]]) else \
+                    pack_128_bool_to_field([false; 128]) fi \
+                  fi \
+                fi \
+              fi \
+            fi \
+          fi \
+        fi \
+      fi \
     fi
 return result
-
-def get_bit_length_bits(field[24] bits) -> (field):
+def get_bit_length_bits(bool[24] bits) -> (field):
     field result = 0
     for field i in 0..24 do
-        result = if (result == 0) && (bits[i] == 1) then 24-i else result fi
+        result = if (result == 0) && (bits[i] == true) then 24-i else result fi
     endfor
 return result
-
-def get_hex_length_bits(field[24] bits) -> (field):
+def get_hex_length_bits(bool[24] bits) -> (field):
     field bit_length = get_bit_length_bits(bits)
     field result = 0
     result = if bit_length > 0 then 1 else result fi
@@ -113,124 +110,64 @@ def get_hex_length_bits(field[24] bits) -> (field):
     result = if bit_length > 16 then 5 else result fi
     result = if bit_length > 20 then 6 else result fi
 return result
-
 // call with last field of block array
-def validate_target(field epoch_head, field epoch_tail, field next_epoch_head) -> (field[2]):
-    field[128] epoch_head_unpacked = unpack128(epoch_head)
-    field[128] epoch_tail_unpacked = unpack128(epoch_tail)
-    field[128] next_epoch_head_unpacked = unpack128(next_epoch_head)
-    field time_head = pack128([...[0; 96], ...toBigEndian(epoch_head_unpacked[32..64])])
-    field time_tail = pack128([...[0; 96], ...toBigEndian(epoch_tail_unpacked[32..64])])
-
+def validate_target(field epoch_head, u32 epoch_tail, u32 next_epoch_head) -> (bool, field):
+    bool[128] epoch_head_unpacked = unpack_field_to_128_bool(epoch_head)
+// 
+    bool[32] epoch_tail_unpacked = u32_to_bits(epoch_tail)
+    bool[32] next_epoch_head_unpacked = u32_to_bits(next_epoch_head)
+    field time_head = pack_128_bool_to_field([...[false; 96], ...toBigEndian(epoch_head_unpacked[32..64])])
+    field time_tail = pack_128_bool_to_field([...[false; 96], ...toBigEndian(epoch_tail_unpacked)])
     field current_target = packTarget(toBigEndian(epoch_head_unpacked[64..96]))
     field time_delta = time_tail - time_head
     field target_time_delta = 1209600 // 2016 * 600 (time interval of 10 minutes)
-
     field target = current_target * time_delta // target_time_delta
-
-    field encoded_target = packTarget(toBigEndian(next_epoch_head_unpacked[64..96]))
+    field encoded_target = packTarget(toBigEndian(next_epoch_head_unpacked))
     field encoded_target_extended = encoded_target * target_time_delta
-
     // The encoding of targets uses a floor function, the comparison of a calculated target may therefore fail
     // Therefore, a maximum variance is calculated that is one hex digit in the encoding
-    field maxVariance = packMaxVariance(getHexLength(target)-get_hex_length_bits(toBigEndian(next_epoch_head_unpacked[64..88])))
+    field maxVariance = packMaxVariance(getHexLength(target)-get_hex_length_bits(toBigEndian(next_epoch_head_unpacked[0..24])))
     // int('ffff' + 10 * '00', 16) * 2016 * 600 = 95832923060582736897701037735936000
     target = if target > 95832923060582736897701037735936000 then 95832923060582736897701037735936000 else target fi
     field delta = target - encoded_target_extended
     delta = if target >= encoded_target_extended then delta else maxVariance + 1 fi
-    field valid = if delta <= maxVariance then 1 else 0 fi
-    //field valid = if (37202390668975264121251936602161152-81015268229227203625641762304819200) < 1267650600228229401496703205375 then 1 else 0 fi
-return [valid, current_target]
-
-def hash_block_header(field[5] preimage) -> (field[2]):
-    field[128] a = unpack128(preimage[0])
-    field[128] b = unpack128(preimage[1])
-    field[128] c = unpack128(preimage[2])
-    field[128] d = unpack128(preimage[3])
-    field[128] e = unpack128(preimage[4])
-
-    field[256] preimage1 = [...a, ...b]
-    field[256] preimage2 = [...c, ...d]
-    field[256] preimage3 = [...[...e, 1], ...[0; 127]]
-    field[256] dummy = [...[0; 246], ...[1, 0, 1, 0, 0, 0, 0, 0, 0, 0]] //second array indicates length of preimage = 640bit
-
-    field[256] intermediary = sha256for1024(preimage1, preimage2, preimage3, dummy)
-
-    field[256] r = sha256only(intermediary)
-
-    field res0 = pack128(r[0..128])
-    field res1 = pack128(r[128..256])
-
-return [res0, res1]
-
-
-def validate_block_header(field reference_target, field[256] bin_prev_block_hash, field[5] preimage) -> (field[257]):
-    a = unpack128(preimage[0])
-	b = unpack128(preimage[1])
-	c = unpack128(preimage[2])
-	d = unpack128(preimage[3])
-	e = unpack128(preimage[4])
-
-    encoded_prev_block_hash1 = pack128([...a[32..128], ...b[0..32]])
-    encoded_prev_block_hash2 = pack128([...b[32..128], ...c[0..32]])
-    field[2] prev_block_hash = [pack128(bin_prev_block_hash[0..128]), pack128(bin_prev_block_hash[128..256])]
-    field valid = if encoded_prev_block_hash1 == prev_block_hash[0] && encoded_prev_block_hash2 == prev_block_hash[1] \\
-        then 1 else 0 fi
-
+    bool valid = if delta <= maxVariance then true else false fi
+return valid, current_target
+def validate_block_header(u32 reference_target, u32[8] prev_block_hash, u32[20] preimage) -> (u32[8]):
+	// preImage: [0] -> Block version, [1:8] -> prev_block_hash, [9:16] -> merkle root, [17:19] => time, target, nonce 
+    assert(preimage[1] == prev_block_hash[0] && \\
+            preimage[2] == prev_block_hash[1] && \\
+            preimage[3] == prev_block_hash[2] && \\
+            preimage[4] == prev_block_hash[3] && \\
+            preimage[5] == prev_block_hash[4] && \\
+            preimage[6] == prev_block_hash[5] && \\
+            preimage[7] == prev_block_hash[6] && \\
+            preimage[8] == prev_block_hash[7])
     // converting to big endian is not necessary here, as reference target is encoded little endian
-    field current_target = pack128([...[0; 96], ...e[64..96]])
-    valid = if valid == 1 && current_target == reference_target then 1 else 0 fi
-
-    field[256] preimage1 = [...a, ...b]
-    field[256] preimage2 = [...c, ...d]
-    field[256] preimage3 = [...[...e, 1], ...[0; 127]]
-    field[256] dummy = [...[0; 246], ...[1, 0, 1, 0, 0, 0, 0, 0, 0, 0]] //second array indicates length of preimage = 640bit
-
-    intermediary = sha256for1024(preimage1, preimage2, preimage3, dummy)
-    
-    r = sha256only(intermediary)
-
-    target = packTarget(toBigEndian(e[64..96]))
-
-    valid = if valid == 1 && target > pack128(toBigEndian(r[128..256])) then 1 else 0 fi
-
-return [valid, ...r]
-
+    assert(preimage[18] == reference_target)
+    u32[8] intermediary = sha256for1024(preimage[0..8], preimage[8..16], [...preimage[16..20], 0x80000000, ...[0x00000000; 3]], [...[0x00000000; 7], 0x00000280])
+    u32[8] r = sha256only(intermediary)
+    field target = packTarget(toBigEndian(u32_to_bits(preimage[18])))
+    assert(target > pack_128_bool_to_field(toBigEndian(u32_4_to_bool_128(r[4..8]))))
+return r
 """
     main_block = []
-    main_block.append("def main(field first_block_epoch, field[2] prev_block_hash, private field[{n_intermediate}][5] intermediate_blocks, field[5] final_block) -> (field[7]):".format(n_intermediate=(n_blocks-1)))
+
+    main_block.append("def main(field epoch_head, u32[8] prev_block_hash, private u32[{n_intermediate}][20] intermediate_blocks, u32[20] final_block) -> (bool, field, u32[8], u32[8]):".format(n_intermediate=(n_blocks-1)))
     main_block.append("""
-    field[128] unpacked_raw_target = unpack128(first_block_epoch)
-    // converting to big endian is not necessary here, as it is compared to a little endian encoding
-    // it is not used for calculations
-    field reference_target = pack128([...[0; 96], ...unpacked_raw_target[64..96]])
-    field result = 1
-    field[128] bin_prev_block_hash1 = unpack128(prev_block_hash[0])
-    field[128] bin_prev_block_hash2 = unpack128(prev_block_hash[1])
-    field[257] block1 = validate_block_header(reference_target, [...bin_prev_block_hash1, ...bin_prev_block_hash2], intermediate_blocks[0])
-    result = if block1[0] == 0 || result == 0 then 0 else 1 fi""")
-
-    blocks = []
-
-    for i in range(1,n_blocks-1):
-        main_block.append("""
-    field[257] block{a} = validate_block_header(reference_target, block{b}[1..257], intermediate_blocks[{b}])
-    result = if block{a}[0] == 0 || result == 0 then 0 else 1 fi""".format(a=i+1, b=i))
-        blocks.append('block' + str(i) + '[1..257]')
-
-    blocks.append('block' + str(n_blocks-1) + '[1..257]')
-    blocks.append('block' + str(n_blocks) + '[1..257]')
+    u32 reference_target = unpack_field_to_4_u32(epoch_head)[2]
+    u32[8] block_hash = prev_block_hash
+    u32[{n_hashes}][8] blocks = [[0x00000000;8];{n_hashes}]
+    for field i in 0..{n_intermediate} do
+      block_hash = validate_block_header(reference_target, block_hash, intermediate_blocks[i])
+      blocks[i] = block_hash
+    endfor""".format(n_hashes=(n_blocks), n_intermediate=(n_blocks - 1)))
 
     main_block.append("""
-    field[128] e = unpack128(final_block[4]) //TODO: Clean up, dirty mirty
-    field[257] block{n_final_block} = validate_block_header(pack128([...[0; 96], ...e[64..96]]), block{n_prev_block}[1..257], final_block)
-    result = if block{n_final_block}[0] == 0 || result == 0 then 0 else 1 fi
-
-    field[2] target_is_valid = validate_target(first_block_epoch, intermediate_blocks[{n_enc_target}][4], final_block[4])
-
-    field[2] merkle_root = compute_merkle_root([{blocks}])
-    field[2] final_block_hash = [pack128(block{n_final_block}[1..129]), pack128(block{n_final_block}[129..257])]
-
-return [result, target_is_valid[0], ...final_block_hash, target_is_valid[1], ...merkle_root]""".format(n_final_block=n_blocks, n_prev_block=n_blocks-1, n_enc_target=n_blocks-2, blocks=','.join(blocks)))
-
+    block_hash = validate_block_header(final_block[18], block_hash, final_block)
+    blocks[{n_intermediate}] = block_hash
+    bool targetValid, field target = validate_target(epoch_head, intermediate_blocks[0][17], final_block[18])
+    u32[8] merkle_root = compute_merkle_root(blocks)
+return targetValid, target, blocks[{n_intermediate}], merkle_root
+    """.format(n_intermediate=(n_blocks - 1)))
     return static_code + "\n".join(main_block)

--- a/getHexLength.zok
+++ b/getHexLength.zok
@@ -1,10 +1,10 @@
-import "utils/pack/unpack128.zok" as unpack128
+import "utils/pack/bool/unpack128.zok" as unpack_field_to_128_bool
 
 def get_bit_length(field word) -> (field):
-    field[128] unpacked_word = unpack128(word)
+    bool[128] unpacked_word = unpack_field_to_128_bool(word)
     field result = 0
     for field i in 0..128 do
-        result = if (result == 0) && (unpacked_word[i] == 1) then 128-i else result fi
+        result = if (result == 0) && (unpacked_word[i] == true) then 128-i else result fi
     endfor
 return result
 

--- a/preprocessing/compute_merkle_path.py
+++ b/preprocessing/compute_merkle_path.py
@@ -1,5 +1,5 @@
-from .create_input import hexToBinaryZokratesInput
-from .create_input import hexToDecimalZokratesInput
+import json
+from .create_input import hexToEightBitHexArray
 
 def compute_merkle_path(tree, element):
     i = tree.index(element)
@@ -21,4 +21,4 @@ def compute_merkle_path(tree, element):
 
 def get_proof_input(tree, element, header):
     path = compute_merkle_path(tree, element)
-    return ' '.join(hexToDecimalZokratesInput(header)) + ' ' + hexToBinaryZokratesInput(''.join(path[0])) + ' ' + ' '.join([str(element) for element in path[1]])
+    return json.dumps([hexToEightBitHexArray(header), [hexToEightBitHexArray(str(element)) for element in path[0]], [str(element) for element in path[1]]]).replace('"', '\\"')

--- a/preprocessing/compute_merkle_path.py
+++ b/preprocessing/compute_merkle_path.py
@@ -1,5 +1,6 @@
 import json
-from .create_input import hexToEightBitHexArray
+from .create_input import hexToEightByteHexArray
+from .create_input import hexToDecimalZokratesInput
 
 def compute_merkle_path(tree, element):
     i = tree.index(element)
@@ -21,4 +22,4 @@ def compute_merkle_path(tree, element):
 
 def get_proof_input(tree, element, header):
     path = compute_merkle_path(tree, element)
-    return json.dumps([hexToEightBitHexArray(header), [hexToEightBitHexArray(str(element)) for element in path[0]], [str(element) for element in path[1]]]).replace('"', '\\"')
+    return json.dumps([hexToDecimalZokratesInput(header), [hexToEightByteHexArray(str(element)) for element in path[0]], [str(element) for element in path[1]]]).replace('"', '\\"')

--- a/preprocessing/create_input.py
+++ b/preprocessing/create_input.py
@@ -1,5 +1,6 @@
 from bitcoinrpc.authproxy import AuthServiceProxy, JSONRPCException
 from bitstring import BitArray
+import json
 
 GENESIS_BLOCK_HASH = '000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f'
 
@@ -50,6 +51,11 @@ def hexToBinaryZokratesInput(input):
     bitarray = BitArray(bytes=preimage)
     return " ".join(bitarray.bin)
 
+def hexToEightBitHexArray(input):
+   return ["0x" + input[i:i+8] for i in range(0,len(input), 8)]
+
+def buildInputJson(epoch_head, prev_block_hash, intermediate_zokrates_blocks, final_zokrates_block):
+    return json.dumps([str(epoch_head), prev_block_hash, intermediate_zokrates_blocks, final_zokrates_block]).replace('"', '\\"')
 
 def createZokratesInputFromBlock(block):
     version = littleEndian(block['versionHex'])
@@ -64,7 +70,6 @@ def createZokratesInputFromBlock(block):
     header = version + little_endian_previousHash + little_endian_merkleRoot + little_endian_time + little_endian_difficultyBits + little_endian_nonce
     return header
 
-
 def generateZokratesInputFromBlock(ctx, first_block, amount):
     last_block = first_block + amount
     blocks = getBlocksInRange(ctx, first_block, last_block)
@@ -72,11 +77,10 @@ def generateZokratesInputFromBlock(ctx, first_block, amount):
     epoch_head = getBlocksInRange(ctx, epoch_header_block_number, epoch_header_block_number+1) \
         if first_block >= 2016 else getBlocksInRange(ctx, 0, 1)
     epoch_head = hexToDecimalZokratesInput(createZokratesInputFromBlock(epoch_head[0]))
-    prev_block_hash = hexToDecimalZokratesInput(littleEndian(getBlocksInRange(ctx, first_block-1,first_block)[0]["hash"]))
-    intermediate_zokrates_blocks = [hexToDecimalZokratesInput(createZokratesInputFromBlock(block)) for block in blocks[0:len(blocks)-1]]
-    intermediate_zokrates_blocks = [item for sublist in intermediate_zokrates_blocks for item in sublist] #flatten
-    final_zokrates_block = hexToDecimalZokratesInput(createZokratesInputFromBlock(blocks[len(blocks)-1]))
-    return str([epoch_head[4], *prev_block_hash, *intermediate_zokrates_blocks, *final_zokrates_block]).replace(',','').replace('[','').replace(']','').replace('\'','')
+    prev_block_hash = hexToEightBitHexArray(littleEndian(getBlocksInRange(ctx, first_block-1,first_block)[0]["hash"]))
+    intermediate_zokrates_blocks = [hexToEightBitHexArray(createZokratesInputFromBlock(block)) for block in blocks[0:len(blocks)-1]]
+    final_zokrates_block = hexToEightBitHexArray(createZokratesInputFromBlock(blocks[len(blocks)-1]))
+    return buildInputJson(epoch_head[4], prev_block_hash, intermediate_zokrates_blocks, final_zokrates_block)
 
 
 def generateZokratesInputForBlocks(ctx, blocks):

--- a/preprocessing/zokrates_helper.py
+++ b/preprocessing/zokrates_helper.py
@@ -4,15 +4,14 @@ import os
 from .create_input import generateZokratesInputFromBlock
 from .create_input import generateZokratesInputForMerkleProof
 
-cmd_echo = 'echo '
-cmd_compute_witness = '| zokrates compute-witness --light --abi --stdin'
+cmd_compute_witness = 'zokrates compute-witness --light -a '
 cmd_generate_proof = 'zokrates generate-proof'
 
 #TODO change BlockNo to BatchNr
 def validateBatchFromBlockNo(ctx, blockNo, batch_size):
-    # result = generateZokratesInputFromBlock(ctx, (blockNo-1)*batch_size+1, batch_size) <- This was the previous implementation, however I don't understand how this should work
+    # result = generateZokratesInputFromBlock(ctx, (blockNo-1)*batch_size+1, batch_size)
     result = generateZokratesInputFromBlock(ctx, blockNo, batch_size)
-    os.system(cmd_echo + result + cmd_compute_witness)
+    os.system(cmd_compute_witness + result)
     os.system(cmd_generate_proof)
     os.system('mv witness output/witness' + str(blockNo))
     os.system('mv proof.json output/proof' + str(blockNo) + '.json')

--- a/preprocessing/zokrates_helper.py
+++ b/preprocessing/zokrates_helper.py
@@ -4,13 +4,15 @@ import os
 from .create_input import generateZokratesInputFromBlock
 from .create_input import generateZokratesInputForMerkleProof
 
-cmd_compute_witness = 'zokrates compute-witness --light -a '
+cmd_echo = 'echo '
+cmd_compute_witness = '| zokrates compute-witness --light --abi --stdin'
 cmd_generate_proof = 'zokrates generate-proof'
 
 #TODO change BlockNo to BatchNr
 def validateBatchFromBlockNo(ctx, blockNo, batch_size):
-    result = generateZokratesInputFromBlock(ctx, (blockNo-1)*batch_size+1, batch_size)
-    os.system(cmd_compute_witness + result)
+    # result = generateZokratesInputFromBlock(ctx, (blockNo-1)*batch_size+1, batch_size) <- This was the previous implementation, however I don't understand how this should work
+    result = generateZokratesInputFromBlock(ctx, blockNo, batch_size)
+    os.system(cmd_echo + result + cmd_compute_witness)
     os.system(cmd_generate_proof)
     os.system('mv witness output/witness' + str(blockNo))
     os.system('mv proof.json output/proof' + str(blockNo) + '.json')

--- a/zkRelay_cli.py
+++ b/zkRelay_cli.py
@@ -134,9 +134,11 @@ def create_merkle_proof(ctx, block_no, bc_host, bc_port, bc_user, bc_pwd):
     tree = preprocessing.compute_full_merkle_tree(block_hashes)
     header = preprocessing.createZokratesInputFromBlock(preprocessing.getBlocksInRange(ctx, block_no, block_no+1)[0])
     zokrates_input = preprocessing.get_proof_input(tree, target_header_hash, header)
+    cmd_echo = 'echo '
+    cmd_compute_witness = '| zokrates compute-witness --light --abi --stdin'
     try:
         click.echo(colored('Exec "zokrates compute-witness --light"', 'cyan'))
-        subprocess.run('zokrates compute-witness --light -a ' + zokrates_input,
+        subprocess.run(cmd_echo + zokrates_input + cmd_compute_witness,
                         check=True, shell=True, cwd="mk_tree_validation/")
         click.echo(colored('Done!', 'green'))
         click.echo(colored('Exec "zokrates generate-proof"', 'cyan'))


### PR DESCRIPTION
This PR updates all necessary files to the newest zokrates syntax. I think one mayor downside with this approach could be the increased number of inputs in the solidity verifier, as we now have a `u32[8]` array representing 256 bits, instead of 2 field elements. Will look into that on Wednesday, to compare the gas costs per verification. 

### Issues:
- Some blocks don't pass the target assertion. This behavior was consistent with the old version though (current master), and I suspect it has something to do with using the testnet. Maybe the hash rate in the testnet is more unstable than mainnet which results in unexpected diff. adjustments? Block #4031 is an example of this. 

### Questions:
I was a bit confused by the way the block numbers get selected when defining the starting block and batch size. When looking at `preprocessing/zokrates_helper.py:13` I don't understand how that worked before, and correct headers where hashed. 

The way I understand it, a batch should consist of a number of blocks, that are all in sequential order. That way, we can sequentially rehash all headers, to make sure they are correct. So when setting `starting_block=1000` and `batch_size=3`, I would expect blocks 1000,1001,1002 to be part of the batch. 

This was implemented differently though, and I honestly can't really make sense of it. 
